### PR TITLE
[#3] 사용자 닉네임으로 사용자 정보 조회 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 }
 
 dependencyManagement {

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'com.h2database:h2'
     annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 }
 

--- a/src/main/java/com/geonwoo/solokill/SolokillApplication.java
+++ b/src/main/java/com/geonwoo/solokill/SolokillApplication.java
@@ -2,8 +2,10 @@ package com.geonwoo.solokill;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 @SpringBootApplication
+@ConfigurationPropertiesScan
 public class SolokillApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/geonwoo/solokill/domain/summoner/converter/SummonerConverter.java
+++ b/src/main/java/com/geonwoo/solokill/domain/summoner/converter/SummonerConverter.java
@@ -15,7 +15,7 @@ public class SummonerConverter {
 			.puuid(summonerInfoResponse.puuid())
 			.name(summonerInfoResponse.name())
 			.profileIconId(summonerInfoResponse.profileIconId())
-			.revisionDate(summonerInfoResponse.revisionData())
+			.revisionDate(summonerInfoResponse.revisionDate())
 			.summonerLevel(summonerInfoResponse.summonerLevel())
 			.build();
 	}
@@ -27,7 +27,7 @@ public class SummonerConverter {
 			.puuid(summoner.getPuuid())
 			.name(summoner.getName())
 			.profileIconId(summoner.getProfileIconId())
-			.revisionData(summoner.getRevisionDate())
+			.revisionDate(summoner.getRevisionDate())
 			.summonerLevel(summoner.getSummonerLevel())
 			.build();
 	}

--- a/src/main/java/com/geonwoo/solokill/domain/summoner/converter/SummonerConverter.java
+++ b/src/main/java/com/geonwoo/solokill/domain/summoner/converter/SummonerConverter.java
@@ -1,0 +1,34 @@
+package com.geonwoo.solokill.domain.summoner.converter;
+
+import org.springframework.stereotype.Component;
+
+import com.geonwoo.solokill.domain.summoner.dto.SummonerInfoResponse;
+import com.geonwoo.solokill.domain.summoner.model.Summoner;
+
+@Component
+public class SummonerConverter {
+
+	public static Summoner toSummoner(SummonerInfoResponse summonerInfoResponse) {
+		return Summoner.builder()
+			.id(summonerInfoResponse.id())
+			.accountId(summonerInfoResponse.accountId())
+			.puuid(summonerInfoResponse.puuid())
+			.name(summonerInfoResponse.name())
+			.profileIconId(summonerInfoResponse.profileIconId())
+			.revisionDate(summonerInfoResponse.revisionData())
+			.summonerLevel(summonerInfoResponse.summonerLevel())
+			.build();
+	}
+
+	public static SummonerInfoResponse toSummonerInfoResponse(Summoner summoner) {
+		return SummonerInfoResponse.builder()
+			.id(summoner.getId())
+			.accountId(summoner.getAccountId())
+			.puuid(summoner.getPuuid())
+			.name(summoner.getName())
+			.profileIconId(summoner.getProfileIconId())
+			.revisionData(summoner.getRevisionDate())
+			.summonerLevel(summoner.getSummonerLevel())
+			.build();
+	}
+}

--- a/src/main/java/com/geonwoo/solokill/domain/summoner/dto/SummonerInfoResponse.java
+++ b/src/main/java/com/geonwoo/solokill/domain/summoner/dto/SummonerInfoResponse.java
@@ -8,18 +8,18 @@ public record SummonerInfoResponse(
 	String puuid,
 	String name,
 	Integer profileIconId,
-	Integer revisionData,
+	Integer revisionDate,
 	Integer summonerLevel
 ) {
 	@Builder
 	public SummonerInfoResponse(String id, String accountId, String puuid, String name, Integer profileIconId,
-		Integer revisionData, Integer summonerLevel) {
+		Integer revisionDate, Integer summonerLevel) {
 		this.id = id;
 		this.accountId = accountId;
 		this.puuid = puuid;
 		this.name = name;
 		this.profileIconId = profileIconId;
-		this.revisionData = revisionData;
+		this.revisionDate = revisionDate;
 		this.summonerLevel = summonerLevel;
 	}
 }

--- a/src/main/java/com/geonwoo/solokill/domain/summoner/dto/SummonerInfoResponse.java
+++ b/src/main/java/com/geonwoo/solokill/domain/summoner/dto/SummonerInfoResponse.java
@@ -1,0 +1,25 @@
+package com.geonwoo.solokill.domain.summoner.dto;
+
+import lombok.Builder;
+
+public record SummonerInfoResponse(
+	String id,
+	String accountId,
+	String puuid,
+	String name,
+	Integer profileIconId,
+	Integer revisionData,
+	Integer summonerLevel
+) {
+	@Builder
+	public SummonerInfoResponse(String id, String accountId, String puuid, String name, Integer profileIconId,
+		Integer revisionData, Integer summonerLevel) {
+		this.id = id;
+		this.accountId = accountId;
+		this.puuid = puuid;
+		this.name = name;
+		this.profileIconId = profileIconId;
+		this.revisionData = revisionData;
+		this.summonerLevel = summonerLevel;
+	}
+}

--- a/src/main/java/com/geonwoo/solokill/domain/summoner/repository/SummonerRepository.java
+++ b/src/main/java/com/geonwoo/solokill/domain/summoner/repository/SummonerRepository.java
@@ -1,8 +1,13 @@
 package com.geonwoo.solokill.domain.summoner.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
 
 import com.geonwoo.solokill.domain.summoner.model.Summoner;
 
 public interface SummonerRepository extends JpaRepository<Summoner, String> {
+
+	Optional<Summoner> findByName(@Param("name") String name);
 }

--- a/src/main/java/com/geonwoo/solokill/domain/summoner/service/SummonerService.java
+++ b/src/main/java/com/geonwoo/solokill/domain/summoner/service/SummonerService.java
@@ -1,0 +1,28 @@
+package com.geonwoo.solokill.domain.summoner.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.geonwoo.solokill.domain.summoner.converter.SummonerConverter;
+import com.geonwoo.solokill.domain.summoner.dto.SummonerInfoResponse;
+import com.geonwoo.solokill.domain.summoner.model.Summoner;
+import com.geonwoo.solokill.domain.summoner.repository.SummonerRepository;
+import com.geonwoo.solokill.global.client.service.ApiClientService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SummonerService {
+
+	private final SummonerRepository summonerRepository;
+	private final ApiClientService apiClientService;
+
+	public SummonerInfoResponse getSummonerInfoByName(String name) {
+		Summoner summoner = summonerRepository.findByName(name)
+			.orElseGet(() -> SummonerConverter.toSummoner(apiClientService.getSummonerInfoByName(name)));
+		return SummonerConverter.toSummonerInfoResponse(summoner);
+	}
+
+}

--- a/src/main/java/com/geonwoo/solokill/global/client/feign/config/FeignConfig.java
+++ b/src/main/java/com/geonwoo/solokill/global/client/feign/config/FeignConfig.java
@@ -4,11 +4,23 @@ import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import com.geonwoo.solokill.global.properties.ApiKeyProperties;
+
 import feign.Logger;
+import feign.RequestInterceptor;
+import lombok.RequiredArgsConstructor;
 
 @Configuration
 @EnableFeignClients("com.geonwoo.solokill")
+@RequiredArgsConstructor
 public class FeignConfig {
+
+	public final ApiKeyProperties apiKeyProperties;
+
+	@Bean
+	public RequestInterceptor requestInterceptor() {
+		return requestTemplate -> requestTemplate.header("X-Riot-Token", apiKeyProperties.key());
+	}
 
 	@Bean
 	public Logger.Level loggerLevel() {

--- a/src/main/java/com/geonwoo/solokill/global/client/feign/feignclient/RiotSummonerOpenFeign.java
+++ b/src/main/java/com/geonwoo/solokill/global/client/feign/feignclient/RiotSummonerOpenFeign.java
@@ -1,0 +1,14 @@
+package com.geonwoo.solokill.global.client.feign.feignclient;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import com.geonwoo.solokill.domain.summoner.dto.SummonerInfoResponse;
+
+@FeignClient(name = "RiotSummonerOpenFeign", url = "${riot-api.url}")
+public interface RiotSummonerOpenFeign {
+
+	@GetMapping(value = "/lol/summoner/v4/summoners/by-name/{summonerName}")
+	SummonerInfoResponse getSummonerInfoByName(@PathVariable("summonerName") String summonerName);
+}

--- a/src/main/java/com/geonwoo/solokill/global/client/feign/service/FeignApiClientService.java
+++ b/src/main/java/com/geonwoo/solokill/global/client/feign/service/FeignApiClientService.java
@@ -1,0 +1,28 @@
+package com.geonwoo.solokill.global.client.feign.service;
+
+import org.springframework.stereotype.Service;
+
+import com.geonwoo.solokill.domain.summoner.converter.SummonerConverter;
+import com.geonwoo.solokill.domain.summoner.dto.SummonerInfoResponse;
+import com.geonwoo.solokill.domain.summoner.model.Summoner;
+import com.geonwoo.solokill.domain.summoner.repository.SummonerRepository;
+import com.geonwoo.solokill.global.client.feign.feignclient.RiotSummonerOpenFeign;
+import com.geonwoo.solokill.global.client.service.ApiClientService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class FeignApiClientService implements ApiClientService {
+
+	private final RiotSummonerOpenFeign riotSummonerOpenFeign;
+	private final SummonerRepository summonerRepository;
+
+	@Override
+	public SummonerInfoResponse getSummonerInfoByName(String name) {
+		SummonerInfoResponse summonerInfoResponse = riotSummonerOpenFeign.getSummonerInfoByName(name);
+		Summoner summoner = SummonerConverter.toSummoner(summonerInfoResponse);
+		summonerRepository.save(summoner);
+		return summonerInfoResponse;
+	}
+}

--- a/src/main/java/com/geonwoo/solokill/global/client/service/ApiClientService.java
+++ b/src/main/java/com/geonwoo/solokill/global/client/service/ApiClientService.java
@@ -1,0 +1,8 @@
+package com.geonwoo.solokill.global.client.service;
+
+import com.geonwoo.solokill.domain.summoner.dto.SummonerInfoResponse;
+
+public interface ApiClientService {
+
+	SummonerInfoResponse getSummonerInfoByName(String name);
+}

--- a/src/main/java/com/geonwoo/solokill/global/properties/ApiKeyProperties.java
+++ b/src/main/java/com/geonwoo/solokill/global/properties/ApiKeyProperties.java
@@ -1,0 +1,9 @@
+package com.geonwoo.solokill.global.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "riot-api")
+public record ApiKeyProperties(
+	String key
+) {
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,3 +18,11 @@ spring:
       hibernate:
         format_sql: true
         dialect: org.hibernate.dialect.MySQLDialect
+
+riot-api:
+  key: ${API_KEY}
+  url: https://kr.api.riotgames.com
+
+logging:
+  level:
+    com.geonwoo.solokll.global.client.feign.feignclient.RiotSummonerOpenFeign: debug

--- a/src/test/java/com/geonwoo/solokill/domain/summoner/repository/SummonerRepositoryTest.java
+++ b/src/test/java/com/geonwoo/solokill/domain/summoner/repository/SummonerRepositoryTest.java
@@ -1,0 +1,38 @@
+package com.geonwoo.solokill.domain.summoner.repository;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.jdbc.Sql;
+
+import com.geonwoo.solokill.domain.summoner.model.Summoner;
+
+@DataJpaTest
+class SummonerRepositoryTest {
+
+	@Autowired
+	private SummonerRepository summonerRepository;
+
+	@Test
+	@DisplayName("소환사 이름으로 소환사 정보를 조회한다.")
+	@Sql(scripts = {"/sql/summoner_dummy.sql"})
+	void findByName() {
+
+		//given
+		String name = "리거누";
+
+		//when
+		Optional<Summoner> optionalSummoner = summonerRepository.findByName(name);
+
+		//then
+		assertTrue(optionalSummoner.isPresent());
+		Summoner summoner = optionalSummoner.get();
+		assertEquals(name, summoner.getName());
+
+	}
+}

--- a/src/test/java/com/geonwoo/solokill/domain/summoner/service/SummonerServiceTest.java
+++ b/src/test/java/com/geonwoo/solokill/domain/summoner/service/SummonerServiceTest.java
@@ -1,0 +1,102 @@
+package com.geonwoo.solokill.domain.summoner.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.jdbc.Sql;
+
+import com.geonwoo.solokill.domain.summoner.dto.SummonerInfoResponse;
+import com.geonwoo.solokill.domain.summoner.model.Summoner;
+import com.geonwoo.solokill.domain.summoner.repository.SummonerRepository;
+import com.geonwoo.solokill.global.client.service.ApiClientService;
+
+@ExtendWith(MockitoExtension.class)
+class SummonerServiceTest {
+
+	@Mock
+	private ApiClientService apiClientService;
+
+	@Mock
+	private SummonerRepository summonerRepository;
+
+	@InjectMocks
+	private SummonerService summonerService;
+
+	@Test
+	@DisplayName("DB에서 소환사의 닉네임으로 소환사 정보를 가져오는데 성공한다.")
+	@Sql(scripts = {"/sql/summoner_dummy.sql"})
+	void getSummonerInfoByName_DB() {
+
+		String name = "리거누";
+		Summoner summoner = Summoner.builder()
+			.id("id")
+			.accountId("accountId")
+			.puuid("puuid")
+			.name("리거누")
+			.profileIconId(123)
+			.revisionDate(123456)
+			.summonerLevel(344)
+			.build();
+
+		Optional<Summoner> optionalSummoner = Optional.of(summoner);
+		when(summonerRepository.findByName(name)).thenReturn(optionalSummoner);
+
+		SummonerInfoResponse summonerInfoByName = summonerService.getSummonerInfoByName(name);
+
+		assertNotNull(summonerInfoByName);
+		assertThat(summonerInfoByName)
+			.hasFieldOrPropertyWithValue("id", summoner.getId())
+			.hasFieldOrPropertyWithValue("accountId", summoner.getAccountId())
+			.hasFieldOrPropertyWithValue("puuid", summoner.getPuuid())
+			.hasFieldOrPropertyWithValue("profileIconId", summoner.getProfileIconId())
+			.hasFieldOrPropertyWithValue("revisionDate", summoner.getRevisionDate())
+			.hasFieldOrPropertyWithValue("summonerLevel", summoner.getSummonerLevel());
+
+		verify(summonerRepository).findByName(name);
+	}
+
+	@Test
+	@DisplayName("소환사 정보가 DB에 없으면 api를 호출하여 정보를 가져오는데 성공한다.")
+	void getSummonerInfoByName_Client() {
+
+		String name = "리거누";
+
+		SummonerInfoResponse summonerInfoResponse = SummonerInfoResponse.builder()
+			.id("id")
+			.accountId("accountId")
+			.puuid("puuid")
+			.name("리거누")
+			.profileIconId(123)
+			.revisionDate(123456)
+			.summonerLevel(344)
+			.build();
+
+		Optional<Summoner> optionalSummoner = Optional.empty();
+		when(summonerRepository.findByName(name)).thenReturn(optionalSummoner);
+		when(apiClientService.getSummonerInfoByName(name)).thenReturn(summonerInfoResponse);
+
+		SummonerInfoResponse summonerInfoByName = summonerService.getSummonerInfoByName(name);
+		assertNotNull(summonerInfoByName);
+
+		assertThat(summonerInfoByName)
+			.hasFieldOrPropertyWithValue("id", summonerInfoByName.id())
+			.hasFieldOrPropertyWithValue("accountId", summonerInfoByName.accountId())
+			.hasFieldOrPropertyWithValue("puuid", summonerInfoByName.puuid())
+			.hasFieldOrPropertyWithValue("profileIconId", summonerInfoByName.profileIconId())
+			.hasFieldOrPropertyWithValue("revisionDate", summonerInfoByName.revisionDate())
+			.hasFieldOrPropertyWithValue("summonerLevel", summonerInfoByName.summonerLevel());
+
+		verify(summonerRepository).findByName(name);
+		verify(apiClientService).getSummonerInfoByName(name);
+
+	}
+}

--- a/src/test/java/com/geonwoo/solokill/global/client/feign/service/FeignApiClientServiceTest.java
+++ b/src/test/java/com/geonwoo/solokill/global/client/feign/service/FeignApiClientServiceTest.java
@@ -1,0 +1,51 @@
+package com.geonwoo.solokill.global.client.feign.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.geonwoo.solokill.domain.summoner.dto.SummonerInfoResponse;
+import com.geonwoo.solokill.global.client.service.ApiClientService;
+
+@ExtendWith(MockitoExtension.class)
+class FeignApiClientServiceTest {
+
+	@Mock
+	private ApiClientService apiClientService;
+
+	@Test
+	@DisplayName("소환사 이름으로 소환사 정보를 호출한다.")
+	public void getSummonerInfoByName() {
+
+		String name = "리거누";
+		SummonerInfoResponse summonerInfoResponse = SummonerInfoResponse.builder()
+			.id("id")
+			.accountId("accountId")
+			.puuid("puuid")
+			.name("리거누")
+			.profileIconId(1234)
+			.revisionDate(1234)
+			.summonerLevel(344)
+			.build();
+
+		when(apiClientService.getSummonerInfoByName(name)).thenReturn(summonerInfoResponse);
+
+		SummonerInfoResponse summonerInfoByName = apiClientService.getSummonerInfoByName(name);
+
+		assertThat(summonerInfoByName)
+			.hasFieldOrPropertyWithValue("id", summonerInfoResponse.id())
+			.hasFieldOrPropertyWithValue("accountId", summonerInfoResponse.accountId())
+			.hasFieldOrPropertyWithValue("puuid", summonerInfoResponse.puuid())
+			.hasFieldOrPropertyWithValue("profileIconId", summonerInfoResponse.profileIconId())
+			.hasFieldOrPropertyWithValue("revisionDate", summonerInfoResponse.revisionDate())
+			.hasFieldOrPropertyWithValue("summonerLevel", summonerInfoResponse.summonerLevel());
+
+		verify(apiClientService).getSummonerInfoByName(name);
+	}
+
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -16,3 +16,6 @@ spring:
       hibernate:
         format_sql: true
         dialect: org.hibernate.dialect.H2Dialect
+
+riot-api:
+  url: https://kr.api.riotgames.com

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,18 @@
+spring:
+
+  datasource:
+    url: jdbc:h2:mem:test;MODE=MySQL
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+
+  jpa:
+    open-in-view: false
+    database: h2
+    show-sql: true
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.H2Dialect

--- a/src/test/resources/sql/summoner_dummy.sql
+++ b/src/test/resources/sql/summoner_dummy.sql
@@ -1,0 +1,2 @@
+insert into summoner (id, account_id, puuid, name, profile_icon_id, revision_date, summoner_level)
+values ('id', 'accountId', 'puuid', '리거누', 1234, 1234, 344);


### PR DESCRIPTION
## ✅ 작업 사항

### 🎩 사용자 닉네임으로 사용자 정보 조회 기능 구현
- 사용자의 닉네임으로 DB에서 사용자 조회
- DB에 없을 경우 api를 호출하여 데이터를 저장하고 조회
- 테스트
- api key 설정

### 💡 관련 이슈
- resolves #3 