### PR TITLE
[#6] 사용자 경기 정보 저장 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'com.h2database:h2'
+    testImplementation 'org.mockito:mockito-inline'
     annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 }
 

--- a/src/main/java/com/geonwoo/solokill/domain/match/converter/MatchConverter.java
+++ b/src/main/java/com/geonwoo/solokill/domain/match/converter/MatchConverter.java
@@ -1,0 +1,30 @@
+package com.geonwoo.solokill.domain.match.converter;
+
+import org.springframework.stereotype.Component;
+
+import com.geonwoo.solokill.domain.match.dto.ParticipantResponse;
+import com.geonwoo.solokill.domain.match.model.Match;
+
+@Component
+public class MatchConverter {
+
+	public static Match toMatch(ParticipantResponse participantResponse) {
+		return Match.builder()
+			.puuid(participantResponse.puuid())
+			.teamId(participantResponse.teamId())
+			.teamPosition(participantResponse.teamPosition())
+			.championName(participantResponse.championName())
+			.soloKills(participantResponse.challenges().soloKills())
+			.visionScore(participantResponse.visionScore())
+			.visionWardsBoughtInGame(participantResponse.visionWardsBoughtInGame())
+			.totalMinionsKilled(participantResponse.totalMinionsKilled())
+			.totalDamageDealtToChampions(participantResponse.totalDamageDealtToChampions())
+			.goldEarned(participantResponse.goldEarned())
+			.championId(participantResponse.championId())
+			.kills(participantResponse.kills())
+			.deaths(participantResponse.deaths())
+			.assists(participantResponse.assists())
+			.win(participantResponse.win())
+			.build();
+	}
+}

--- a/src/main/java/com/geonwoo/solokill/domain/match/dto/ChallengesResponse.java
+++ b/src/main/java/com/geonwoo/solokill/domain/match/dto/ChallengesResponse.java
@@ -1,0 +1,6 @@
+package com.geonwoo.solokill.domain.match.dto;
+
+public record ChallengesResponse(
+	Integer soloKills
+) {
+}

--- a/src/main/java/com/geonwoo/solokill/domain/match/dto/MatchInfo.java
+++ b/src/main/java/com/geonwoo/solokill/domain/match/dto/MatchInfo.java
@@ -1,0 +1,8 @@
+package com.geonwoo.solokill.domain.match.dto;
+
+import java.util.List;
+
+public record MatchInfo(
+	List<ParticipantResponse> participants
+) {
+}

--- a/src/main/java/com/geonwoo/solokill/domain/match/dto/MatchResponse.java
+++ b/src/main/java/com/geonwoo/solokill/domain/match/dto/MatchResponse.java
@@ -1,0 +1,6 @@
+package com.geonwoo.solokill.domain.match.dto;
+
+public record MatchResponse(
+	MatchInfo info
+) {
+}

--- a/src/main/java/com/geonwoo/solokill/domain/match/dto/ParticipantResponse.java
+++ b/src/main/java/com/geonwoo/solokill/domain/match/dto/ParticipantResponse.java
@@ -1,0 +1,20 @@
+package com.geonwoo.solokill.domain.match.dto;
+
+public record ParticipantResponse(
+	String puuid,
+	Integer teamId,
+	String teamPosition,
+	String championName,
+	ChallengesResponse challenges,
+	Integer visionScore,
+	Integer visionWardsBoughtInGame,
+	Integer totalMinionsKilled,
+	Integer totalDamageDealtToChampions,
+	Integer goldEarned,
+	Integer championId,
+	Integer kills,
+	Integer deaths,
+	Integer assists,
+	Boolean win
+) {
+}

--- a/src/main/java/com/geonwoo/solokill/domain/match/model/Match.java
+++ b/src/main/java/com/geonwoo/solokill/domain/match/model/Match.java
@@ -78,4 +78,8 @@ public class Match {
 	public void addMatch(Match opponentMatch) {
 		this.opponentMatch = opponentMatch;
 	}
+
+	public boolean isSameTeamPosition(String teamPosition) {
+		return this.teamPosition.equals(teamPosition);
+	}
 }

--- a/src/main/java/com/geonwoo/solokill/global/client/feign/feignclient/RiotMatchOpenFeign.java
+++ b/src/main/java/com/geonwoo/solokill/global/client/feign/feignclient/RiotMatchOpenFeign.java
@@ -1,0 +1,21 @@
+package com.geonwoo.solokill.global.client.feign.feignclient;
+
+import java.util.List;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import com.geonwoo.solokill.domain.match.dto.MatchResponse;
+
+@FeignClient(name = "RiotMatchOpenFeign", url = "${riot-api.url}")
+public interface RiotMatchOpenFeign {
+
+	@GetMapping(value = "/lol/match/v5/matches/by-puuid/{puuid}/ids")
+	List<String> getMatchId(@PathVariable("puuid") String puuid
+		, @RequestParam("type") String type, @RequestParam("count") Integer count);
+
+	@GetMapping(value = "/lol/match/v5/matches/{matchId}")
+	MatchResponse getMatchByMatchId(@PathVariable("matchId") String matchId);
+}

--- a/src/main/java/com/geonwoo/solokill/global/client/feign/service/FeignApiClientService.java
+++ b/src/main/java/com/geonwoo/solokill/global/client/feign/service/FeignApiClientService.java
@@ -1,11 +1,20 @@
 package com.geonwoo.solokill.global.client.feign.service;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 
+import com.geonwoo.solokill.domain.match.converter.MatchConverter;
+import com.geonwoo.solokill.domain.match.dto.MatchResponse;
+import com.geonwoo.solokill.domain.match.dto.ParticipantResponse;
+import com.geonwoo.solokill.domain.match.model.Match;
+import com.geonwoo.solokill.domain.match.repository.MatchRepository;
 import com.geonwoo.solokill.domain.summoner.converter.SummonerConverter;
 import com.geonwoo.solokill.domain.summoner.dto.SummonerInfoResponse;
 import com.geonwoo.solokill.domain.summoner.model.Summoner;
 import com.geonwoo.solokill.domain.summoner.repository.SummonerRepository;
+import com.geonwoo.solokill.global.client.feign.feignclient.RiotMatchOpenFeign;
 import com.geonwoo.solokill.global.client.feign.feignclient.RiotSummonerOpenFeign;
 import com.geonwoo.solokill.global.client.service.ApiClientService;
 
@@ -15,7 +24,11 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class FeignApiClientService implements ApiClientService {
 
+	private static String GAME_TYPE = "ranked";
+	private static Integer GAME_COUNT = 50;
 	private final RiotSummonerOpenFeign riotSummonerOpenFeign;
+	private final RiotMatchOpenFeign riotMatchOpenFeign;
+	private final MatchRepository matchRepository;
 	private final SummonerRepository summonerRepository;
 
 	@Override
@@ -24,5 +37,44 @@ public class FeignApiClientService implements ApiClientService {
 		Summoner summoner = SummonerConverter.toSummoner(summonerInfoResponse);
 		summonerRepository.save(summoner);
 		return summonerInfoResponse;
+	}
+
+	@Override
+	public void getMatchInfoByPuuid(String puuid) {
+		List<String> matchIdResponses = riotMatchOpenFeign.getMatchId(puuid, GAME_TYPE, GAME_COUNT);
+
+		for (String matchId : matchIdResponses) {
+			MatchResponse matchResponse = riotMatchOpenFeign.getMatchByMatchId(matchId);
+			List<ParticipantResponse> participantResponses = matchResponse.info().participants();
+
+			String teamPosition = "";
+			List<Match> matchInfos = new ArrayList<>();
+
+			for (ParticipantResponse participantResponse : participantResponses) {
+				if (puuid.equals(participantResponse.puuid())) {
+					teamPosition = participantResponse.teamPosition();
+					Match match = MatchConverter.toMatch(participantResponse);
+					matchInfos.add(match);
+				}
+			}
+			for (ParticipantResponse participantResponse : participantResponses) {
+				if (teamPosition.equals(participantResponse.teamPosition()) && !puuid.equals(
+					participantResponse.puuid())) {
+					Match match = MatchConverter.toMatch(participantResponse);
+
+					matchInfos.add(match);
+				}
+			}
+			Match match1;
+			Match match2;
+			if (matchInfos.size() >= 2) {
+				match1 = matchInfos.get(0);
+				match2 = matchInfos.get(1);
+				match1.addMatch(match2);
+				match2.addMatch(match1);
+				matchRepository.save(match1);
+				matchRepository.save(match2);
+			}
+		}
 	}
 }

--- a/src/main/java/com/geonwoo/solokill/global/client/service/ApiClientService.java
+++ b/src/main/java/com/geonwoo/solokill/global/client/service/ApiClientService.java
@@ -5,4 +5,6 @@ import com.geonwoo.solokill.domain.summoner.dto.SummonerInfoResponse;
 public interface ApiClientService {
 
 	SummonerInfoResponse getSummonerInfoByName(String name);
+
+	void getMatchInfoByPuuid(String puuid);
 }

--- a/src/test/java/com/geonwoo/solokill/global/client/feign/service/FeignApiClientServiceTest.java
+++ b/src/test/java/com/geonwoo/solokill/global/client/feign/service/FeignApiClientServiceTest.java
@@ -3,20 +3,42 @@ package com.geonwoo.solokill.global.client.feign.service;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.geonwoo.solokill.domain.match.dto.ChallengesResponse;
+import com.geonwoo.solokill.domain.match.dto.MatchInfo;
+import com.geonwoo.solokill.domain.match.dto.MatchResponse;
+import com.geonwoo.solokill.domain.match.dto.ParticipantResponse;
+import com.geonwoo.solokill.domain.summoner.converter.SummonerConverter;
 import com.geonwoo.solokill.domain.summoner.dto.SummonerInfoResponse;
-import com.geonwoo.solokill.global.client.service.ApiClientService;
+import com.geonwoo.solokill.domain.summoner.model.Summoner;
+import com.geonwoo.solokill.domain.summoner.repository.SummonerRepository;
+import com.geonwoo.solokill.global.client.feign.feignclient.RiotMatchOpenFeign;
+import com.geonwoo.solokill.global.client.feign.feignclient.RiotSummonerOpenFeign;
 
 @ExtendWith(MockitoExtension.class)
 class FeignApiClientServiceTest {
 
+	@InjectMocks
+	private FeignApiClientService feignApiClientService;
+
 	@Mock
-	private ApiClientService apiClientService;
+	private RiotSummonerOpenFeign riotSummonerOpenFeign;
+
+	@Mock
+	private RiotMatchOpenFeign riotMatchOpenFeign;
+
+	@Mock
+	private SummonerRepository summonerRepository;
 
 	@Test
 	@DisplayName("소환사 이름으로 소환사 정보를 호출한다.")
@@ -34,10 +56,23 @@ class FeignApiClientServiceTest {
 			.summonerLevel(344)
 			.build();
 
-		when(apiClientService.getSummonerInfoByName(name)).thenReturn(summonerInfoResponse);
+		Summoner summoner = Summoner.builder()
+			.id("id")
+			.accountId("accountId")
+			.puuid("puuid")
+			.name("리거누")
+			.profileIconId(1234)
+			.revisionDate(1234)
+			.summonerLevel(344)
+			.build();
+
+		MockedStatic<SummonerConverter> summonerConverterMockedStatic = mockStatic(SummonerConverter.class);
+		when(riotSummonerOpenFeign.getSummonerInfoByName(name)).thenReturn(summonerInfoResponse);
+		when(SummonerConverter.toSummoner(summonerInfoResponse)).thenReturn(summoner);
+		when(summonerRepository.save(summoner)).thenReturn(summoner);
 
 		//when
-		SummonerInfoResponse summonerInfoByName = apiClientService.getSummonerInfoByName(name);
+		SummonerInfoResponse summonerInfoByName = feignApiClientService.getSummonerInfoByName(name);
 
 		//then
 		assertThat(summonerInfoByName)
@@ -48,7 +83,40 @@ class FeignApiClientServiceTest {
 			.hasFieldOrPropertyWithValue("revisionDate", summonerInfoResponse.revisionDate())
 			.hasFieldOrPropertyWithValue("summonerLevel", summonerInfoResponse.summonerLevel());
 
-		verify(apiClientService).getSummonerInfoByName(name);
+		verify(riotSummonerOpenFeign).getSummonerInfoByName(name);
+		verify(summonerRepository).save(summoner);
+		summonerConverterMockedStatic.verify(() -> SummonerConverter.toSummoner(summonerInfoResponse), times(1));
 	}
 
+	@Test
+	@DisplayName("소환사의 puuid로 경기id를 조회하고, 경기id로 경기를 조회하여 사용자의 경기 기록과, 사용자 맞라인 상대의 경기 기록을 저장한다.")
+	void getMatchInfoByPuuid() {
+
+		String puuid = "puuid";
+		String gameType = "ranked";
+		Integer gameCount = 50;
+		String matchId = "matchId";
+		List<String> matchIds = new ArrayList<>();
+		matchIds.add(matchId);
+		when(riotMatchOpenFeign.getMatchId(puuid, gameType, gameCount)).thenReturn(matchIds);
+
+		ChallengesResponse challengesResponse = new ChallengesResponse(1);
+		ParticipantResponse participantResponse1 = new ParticipantResponse(puuid, 1, "TOP", "Jayce", challengesResponse,
+			1, 1, 1, 1, 1, 1, 1, 1, 1, true);
+		ParticipantResponse participantResponse2 = new ParticipantResponse("puuid2", 2, "TOP", "Gnar",
+			challengesResponse,
+			1, 1, 1, 1, 1, 1, 1, 1, 1, false);
+		List<ParticipantResponse> participants = new ArrayList<>();
+		participants.add(participantResponse1);
+		participants.add(participantResponse2);
+		MatchInfo matchInfo = new MatchInfo(participants);
+		MatchResponse matchResponse = new MatchResponse(matchInfo);
+
+		when(riotMatchOpenFeign.getMatchByMatchId(matchId)).thenReturn(matchResponse);
+
+		feignApiClientService.getMatchInfoByPuuid(puuid);
+
+		verify(riotMatchOpenFeign).getMatchId(puuid, gameType, gameCount);
+		verify(riotMatchOpenFeign).getMatchByMatchId(matchId);
+	}
 }


### PR DESCRIPTION
## ✅  작업 사항

### 💾 사용자 경기 정보 저장 기능 구현
- 사용자의 puuid로 사용자의 경기 아이디를 조회하고, 조회한 경기아이디로 경기 상세정보 조회
- 나의 경기 정보와 맞라인 상대의 경기 정보 저장
- 테스트

### 💡 관련 이슈
- resolves #6 