### PR TITLE
[#27] Summoner 리펙토링

### DIFF
--- a/src/main/java/com/geonwoo/solokill/domain/matchInfo/model/MatchInfo.java
+++ b/src/main/java/com/geonwoo/solokill/domain/matchInfo/model/MatchInfo.java
@@ -3,12 +3,16 @@ package com.geonwoo.solokill.domain.matchInfo.model;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.springframework.data.domain.Persistable;
+
 import com.geonwoo.solokill.domain.matchrecord.model.MatchRecord;
 
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.PostLoad;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Transient;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -16,9 +20,9 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class MatchInfo {
+public class MatchInfo implements Persistable<String> {
 
-	@OneToMany(mappedBy = "matchInfo", cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true)
+	@OneToMany(mappedBy = "matchInfo", orphanRemoval = true)
 	private final List<MatchRecord> matchRecords = new ArrayList<>();
 
 	@Id
@@ -30,6 +34,24 @@ public class MatchInfo {
 
 	public void addMatchRecord(MatchRecord matchRecords) {
 		this.matchRecords.add(matchRecords);
-		matchRecords.addMatch(this);
+	}
+
+	@Transient
+	private boolean isNew = true;
+
+	@Override
+	public String getId() {
+		return id;
+	}
+
+	@Override
+	public boolean isNew() {
+		return isNew;
+	}
+
+	@PrePersist
+	@PostLoad
+	void markNotNew() {
+		this.isNew = false;
 	}
 }

--- a/src/main/java/com/geonwoo/solokill/domain/matchInfo/repository/MatchInfoRepository.java
+++ b/src/main/java/com/geonwoo/solokill/domain/matchInfo/repository/MatchInfoRepository.java
@@ -1,4 +1,4 @@
-package com.geonwoo.solokill.domain.matchrecord.repository;
+package com.geonwoo.solokill.domain.matchInfo.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/src/main/java/com/geonwoo/solokill/domain/matchrecord/controller/MatchRecordController.java
+++ b/src/main/java/com/geonwoo/solokill/domain/matchrecord/controller/MatchRecordController.java
@@ -21,9 +21,9 @@ public class MatchRecordController {
 	private final MatchRecordService matchRecordService;
 
 	@GetMapping("/matchRecord/{summonerName}")
-	public ResponseEntity<ApiResponse<List<PlayerChampionResponse>>> getSummonerInfo(
+	public ResponseEntity<ApiResponse<List<String>>> getSummonerInfo(
 		@PathVariable("summonerName") String name) {
-		List<PlayerChampionResponse> responses = matchRecordService.getPlayerChampionByName(name);
+		List<String> responses = matchRecordService.getPlayerChampionByName(name);
 		return ResponseEntity.ok(new ApiResponse<>(responses));
 	}
 

--- a/src/main/java/com/geonwoo/solokill/domain/matchrecord/converter/MatchRecordConverter.java
+++ b/src/main/java/com/geonwoo/solokill/domain/matchrecord/converter/MatchRecordConverter.java
@@ -4,12 +4,15 @@ import org.springframework.stereotype.Component;
 
 import com.geonwoo.solokill.domain.matchrecord.dto.ParticipantResponse;
 import com.geonwoo.solokill.domain.matchrecord.model.MatchRecord;
+import com.geonwoo.solokill.domain.summoner.model.Summoner;
 
 @Component
 public class MatchRecordConverter {
 
-	public static MatchRecord toMatchRecord(ParticipantResponse participantResponse) {
-		return MatchRecord.builder()
+	public static MatchRecord toMatchRecord(ParticipantResponse participantResponse, String matchInfoId) {
+		MatchRecord matchRecord = MatchRecord.builder()
+			.summonerId(participantResponse.summonerId())
+			.matchInfoId(matchInfoId)
 			.teamId(participantResponse.teamId())
 			.teamPosition(participantResponse.teamPosition())
 			.championName(participantResponse.championName())
@@ -25,5 +28,17 @@ public class MatchRecordConverter {
 			.assists(participantResponse.assists())
 			.win(participantResponse.win())
 			.build();
+
+		Summoner summoner = Summoner.builder()
+			.id(participantResponse.summonerId())
+			.name(participantResponse.summonerName())
+			.puuid(participantResponse.puuid())
+			.profileIconId(participantResponse.profileIcon())
+			.summonerLevel(participantResponse.summonerLevel())
+			.build();
+
+		matchRecord.addSummoner(summoner);
+
+		return matchRecord;
 	}
 }

--- a/src/main/java/com/geonwoo/solokill/domain/matchrecord/dto/ParticipantResponse.java
+++ b/src/main/java/com/geonwoo/solokill/domain/matchrecord/dto/ParticipantResponse.java
@@ -1,7 +1,6 @@
 package com.geonwoo.solokill.domain.matchrecord.dto;
 
 public record ParticipantResponse(
-	String puuid,
 	Integer teamId,
 	String teamPosition,
 	String championName,
@@ -15,6 +14,11 @@ public record ParticipantResponse(
 	Integer kills,
 	Integer deaths,
 	Integer assists,
-	Boolean win
+	Boolean win,
+	String summonerId,
+	String puuid,
+	String summonerName,
+	Integer profileIcon,
+	Integer summonerLevel
 ) {
 }

--- a/src/main/java/com/geonwoo/solokill/domain/matchrecord/model/MatchRecordPk.java
+++ b/src/main/java/com/geonwoo/solokill/domain/matchrecord/model/MatchRecordPk.java
@@ -1,0 +1,23 @@
+package com.geonwoo.solokill.domain.matchrecord.model;
+
+import java.io.Serializable;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@NoArgsConstructor
+@EqualsAndHashCode
+@AllArgsConstructor
+public class MatchRecordPk implements Serializable {
+
+	@Column(name = "summoner_id")
+	private String summonerId;
+
+	@Column(name = "match_info_id")
+	private String matchInfoId;
+
+}

--- a/src/main/java/com/geonwoo/solokill/domain/matchrecord/repository/MatchRecordRepository.java
+++ b/src/main/java/com/geonwoo/solokill/domain/matchrecord/repository/MatchRecordRepository.java
@@ -8,9 +8,10 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import com.geonwoo.solokill.domain.matchrecord.model.MatchRecord;
+import com.geonwoo.solokill.domain.matchrecord.model.MatchRecordPk;
 
 public interface MatchRecordRepository
-	extends JpaRepository<MatchRecord, Long> {
+	extends JpaRepository<MatchRecord, MatchRecordPk> {
 
 	@Query("""
 		SELECT m.championName

--- a/src/main/java/com/geonwoo/solokill/domain/matchrecord/service/MatchRecordService.java
+++ b/src/main/java/com/geonwoo/solokill/domain/matchrecord/service/MatchRecordService.java
@@ -9,7 +9,6 @@ import java.util.Set;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.geonwoo.solokill.domain.matchrecord.dto.PlayerChampionResponse;
 import com.geonwoo.solokill.domain.matchrecord.dto.PlayerMatchUpResponse;
 import com.geonwoo.solokill.domain.matchrecord.model.MatchRecord;
 import com.geonwoo.solokill.domain.matchrecord.repository.MatchRecordRepository;
@@ -24,23 +23,23 @@ import lombok.RequiredArgsConstructor;
 @Transactional(readOnly = true)
 public class MatchRecordService {
 
-	private final MatchRecordRepository matchRepository;
+	private final MatchRecordRepository matchRecordRepository;
 	private final SummonerService summonerService;
 	private final ApiClientService apiClientService;
 
 	@Transactional
-	public List<PlayerChampionResponse> getPlayerChampionByName(String name) {
+	public List<String> getPlayerChampionByName(String name) {
 		SummonerInfoResponse summonerInfoByName = summonerService.getSummonerInfoByName(name);
 		apiClientService.getMatchInfoByPuuid(summonerInfoByName.puuid());
-		Set<String> championNameByPuuid = matchRepository.findChampionNameByPuuid(summonerInfoByName.puuid());
-		return championNameByPuuid.stream().map(PlayerChampionResponse::new).toList();
+		Set<String> championNameByPuuid = matchRecordRepository.findChampionNameByPuuid(summonerInfoByName.puuid());
+		return championNameByPuuid.stream().toList();
 	}
 
 	public List<PlayerMatchUpResponse> getPlayerMatchUpByChampionName(String name, String championName) {
 
 		SummonerInfoResponse summonerInfoByName = summonerService.getSummonerInfoByName(name);
 
-		List<MatchRecord> matchRecords = matchRepository.findAllByPuuidAndChampionName(summonerInfoByName.puuid(),
+		List<MatchRecord> matchRecords = matchRecordRepository.findAllByPuuidAndChampionName(summonerInfoByName.puuid(),
 			championName);
 
 		Set<String> opponentChampion = new HashSet<>();

--- a/src/main/java/com/geonwoo/solokill/domain/summoner/converter/SummonerConverter.java
+++ b/src/main/java/com/geonwoo/solokill/domain/summoner/converter/SummonerConverter.java
@@ -11,11 +11,9 @@ public class SummonerConverter {
 	public static Summoner toSummoner(SummonerInfoResponse summonerInfoResponse) {
 		return Summoner.builder()
 			.id(summonerInfoResponse.id())
-			.accountId(summonerInfoResponse.accountId())
 			.puuid(summonerInfoResponse.puuid())
 			.name(summonerInfoResponse.name())
 			.profileIconId(summonerInfoResponse.profileIconId())
-			.revisionDate(summonerInfoResponse.revisionDate())
 			.summonerLevel(summonerInfoResponse.summonerLevel())
 			.build();
 	}
@@ -23,11 +21,9 @@ public class SummonerConverter {
 	public static SummonerInfoResponse toSummonerInfoResponse(Summoner summoner) {
 		return SummonerInfoResponse.builder()
 			.id(summoner.getId())
-			.accountId(summoner.getAccountId())
 			.puuid(summoner.getPuuid())
 			.name(summoner.getName())
 			.profileIconId(summoner.getProfileIconId())
-			.revisionDate(summoner.getRevisionDate())
 			.summonerLevel(summoner.getSummonerLevel())
 			.build();
 	}

--- a/src/main/java/com/geonwoo/solokill/domain/summoner/dto/SummonerInfoResponse.java
+++ b/src/main/java/com/geonwoo/solokill/domain/summoner/dto/SummonerInfoResponse.java
@@ -4,22 +4,17 @@ import lombok.Builder;
 
 public record SummonerInfoResponse(
 	String id,
-	String accountId,
 	String puuid,
 	String name,
 	Integer profileIconId,
-	Long revisionDate,
 	Integer summonerLevel
 ) {
 	@Builder
-	public SummonerInfoResponse(String id, String accountId, String puuid, String name, Integer profileIconId,
-		Long revisionDate, Integer summonerLevel) {
+	public SummonerInfoResponse(String id,String puuid, String name, Integer profileIconId, Integer summonerLevel) {
 		this.id = id;
-		this.accountId = accountId;
 		this.puuid = puuid;
 		this.name = name;
 		this.profileIconId = profileIconId;
-		this.revisionDate = revisionDate;
 		this.summonerLevel = summonerLevel;
 	}
 }

--- a/src/main/java/com/geonwoo/solokill/domain/summoner/model/Summoner.java
+++ b/src/main/java/com/geonwoo/solokill/domain/summoner/model/Summoner.java
@@ -7,7 +7,9 @@ import com.geonwoo.solokill.domain.matchrecord.model.MatchRecord;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,12 +18,11 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "summoner", indexes = @Index(name = "idx_puuid", columnList = "puuid"))
 public class Summoner {
 
 	@Id
 	private String id;
-
-	private String accountId;
 
 	private String puuid;
 
@@ -29,22 +30,17 @@ public class Summoner {
 
 	private Integer profileIconId;
 
-	private Long revisionDate;
-
 	private Integer summonerLevel;
 
 	@OneToMany(mappedBy = "summoner")
 	private List<MatchRecord> match = new ArrayList<>();
 
 	@Builder
-	protected Summoner(String id, String accountId, String puuid, String name, Integer profileIconId,
-		Long revisionDate, Integer summonerLevel) {
+	protected Summoner(String id, String puuid, String name, Integer profileIconId, Integer summonerLevel) {
 		this.id = id;
-		this.accountId = accountId;
 		this.puuid = puuid;
 		this.name = name;
 		this.profileIconId = profileIconId;
-		this.revisionDate = revisionDate;
 		this.summonerLevel = summonerLevel;
 	}
 

--- a/src/main/java/com/geonwoo/solokill/domain/summoner/model/Summoner.java
+++ b/src/main/java/com/geonwoo/solokill/domain/summoner/model/Summoner.java
@@ -3,13 +3,18 @@ package com.geonwoo.solokill.domain.summoner.model;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.springframework.data.domain.Persistable;
+
 import com.geonwoo.solokill.domain.matchrecord.model.MatchRecord;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.PostLoad;
+import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,8 +23,8 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "summoner", indexes = @Index(name = "idx_puuid", columnList = "puuid"))
-public class Summoner {
+@Table(name = "summoner", indexes = @Index(name = "idx_puuid", unique = true, columnList = "puuid"))
+public class Summoner implements Persistable<String> {
 
 	@Id
 	private String id;
@@ -44,7 +49,27 @@ public class Summoner {
 		this.summonerLevel = summonerLevel;
 	}
 
-	public void addMatch(MatchRecord match) {
-		this.match.add(match);
+	@Transient
+	private boolean isNew = true;
+
+	@Override
+	public String getId() {
+		return id;
 	}
+
+	@Override
+	public boolean isNew() {
+		return isNew;
+	}
+
+	@PrePersist
+	@PostLoad
+	void markNotNew() {
+		this.isNew = false;
+	}
+
+	public void addMatchRecord(MatchRecord matchRecord) {
+		this.match.add(matchRecord);
+	}
+
 }

--- a/src/main/java/com/geonwoo/solokill/domain/summoner/service/SummonerService.java
+++ b/src/main/java/com/geonwoo/solokill/domain/summoner/service/SummonerService.java
@@ -19,6 +19,7 @@ public class SummonerService {
 	private final SummonerRepository summonerRepository;
 	private final ApiClientService apiClientService;
 
+	@Transactional
 	public SummonerInfoResponse getSummonerInfoByName(String name) {
 		Summoner summoner = summonerRepository.findByName(name)
 			.orElseGet(() -> SummonerConverter.toSummoner(apiClientService.getSummonerInfoByName(name)));

--- a/src/main/java/com/geonwoo/solokill/global/client/feign/service/FeignApiClientService.java
+++ b/src/main/java/com/geonwoo/solokill/global/client/feign/service/FeignApiClientService.java
@@ -3,12 +3,14 @@ package com.geonwoo.solokill.global.client.feign.service;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import com.geonwoo.solokill.domain.matchInfo.model.MatchInfo;
 import com.geonwoo.solokill.domain.matchrecord.converter.MatchRecordConverter;
 import com.geonwoo.solokill.domain.matchrecord.dto.MatchResponse;
-import com.geonwoo.solokill.domain.matchInfo.model.MatchInfo;
 import com.geonwoo.solokill.domain.matchrecord.model.MatchRecord;
-import com.geonwoo.solokill.domain.matchrecord.repository.MatchInfoRepository;
+import com.geonwoo.solokill.domain.matchrecord.model.MatchRecordPk;
+import com.geonwoo.solokill.domain.matchInfo.repository.MatchInfoRepository;
 import com.geonwoo.solokill.domain.matchrecord.repository.MatchRecordRepository;
 import com.geonwoo.solokill.domain.summoner.converter.SummonerConverter;
 import com.geonwoo.solokill.domain.summoner.dto.SummonerInfoResponse;
@@ -19,22 +21,22 @@ import com.geonwoo.solokill.global.client.feign.feignclient.RiotSummonerOpenFeig
 import com.geonwoo.solokill.global.client.service.ApiClientService;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class FeignApiClientService implements ApiClientService {
 
 	private static String GAME_TYPE = "ranked";
 	private static Integer GAME_COUNT = 3;
 	private final RiotSummonerOpenFeign riotSummonerOpenFeign;
 	private final RiotMatchOpenFeign riotMatchOpenFeign;
-	private final MatchInfoRepository matchRepository;
-	private final SummonerRepository summonerRepository;
+	private final MatchInfoRepository matchInfoRepository;
 	private final MatchRecordRepository matchRecordRepository;
+	private final SummonerRepository summonerRepository;
 
 	@Override
+	@Transactional
 	public SummonerInfoResponse getSummonerInfoByName(String name) {
 		SummonerInfoResponse summonerInfoResponse = riotSummonerOpenFeign.getSummonerInfoByName(name);
 		Summoner summoner = SummonerConverter.toSummoner(summonerInfoResponse);
@@ -43,27 +45,26 @@ public class FeignApiClientService implements ApiClientService {
 	}
 
 	@Override
+	@Transactional
 	public void getMatchInfoByPuuid(String puuid) {
-
 		List<String> matchIds = riotMatchOpenFeign.getMatchId(puuid, GAME_TYPE, GAME_COUNT);
-		for (String matchId : matchIds) {
-			if (matchRepository.findById(matchId).isPresent()) {
-				continue;
+
+		matchIds.forEach(matchId -> {
+			if (!matchInfoRepository.existsById(matchId)) {
+				MatchInfo matchInfo = new MatchInfo(matchId);
+				MatchResponse matchResponse = riotMatchOpenFeign.getMatchByMatchId(matchId);
+
+				matchResponse.info().participants().forEach(participantResponse ->
+					{
+						if (!summonerRepository.existsById(participantResponse.summonerId()) &&
+							!matchRecordRepository.existsById(new MatchRecordPk(participantResponse.summonerId(), matchId))) {
+							MatchRecord matchRecord = MatchRecordConverter.toMatchRecord(participantResponse, matchId);
+							matchRecord.addMatch(matchInfo);
+							matchRecordRepository.save(matchRecord);
+						}
+					}
+				);
 			}
-			MatchInfo matchInfo = new MatchInfo(matchId);
-			MatchResponse matchResponse = riotMatchOpenFeign.getMatchByMatchId(matchId);
-			log.info("{}", matchResponse);
-			List<MatchRecord> playerMatchRecords = matchResponse.info().participants().stream().map(a -> {
-				SummonerInfoResponse summonerInfoByPuuid = riotSummonerOpenFeign.getSummonerInfoByPuuid(a.puuid());
-				Summoner summoner = SummonerConverter.toSummoner(summonerInfoByPuuid);
-				summonerRepository.save(summoner);
-				MatchRecord matchRecord = MatchRecordConverter.toMatchRecord(a);
-				matchRecord.addSummoner(summoner);
-				matchInfo.addMatchRecord(matchRecord);
-				return matchRecord;
-			}).toList();
-			matchRepository.save(matchInfo);
-			matchRecordRepository.saveAll(playerMatchRecords);
-		}
+		});
 	}
 }

--- a/src/main/java/com/geonwoo/solokill/global/config/P6SpyFormatter.java
+++ b/src/main/java/com/geonwoo/solokill/global/config/P6SpyFormatter.java
@@ -1,0 +1,54 @@
+package com.geonwoo.solokill.global.config;
+
+import java.sql.SQLException;
+
+import org.hibernate.engine.jdbc.internal.FormatStyle;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import com.p6spy.engine.common.ConnectionInformation;
+import com.p6spy.engine.event.JdbcEventListener;
+import com.p6spy.engine.spy.P6SpyOptions;
+import com.p6spy.engine.spy.appender.MessageFormattingStrategy;
+
+@Component
+public class P6SpyFormatter extends JdbcEventListener implements MessageFormattingStrategy {
+
+	@Override
+	public void onAfterGetConnection(ConnectionInformation connectionInformation, SQLException e) {
+		P6SpyOptions.getActiveInstance().setLogMessageFormat(getClass().getName());
+	}
+
+	@Override
+	public String formatMessage(int connectionId, String now, long elapsed, String category, String prepared,
+		String sql, String url) {
+		StringBuilder sb = new StringBuilder();
+		sb.append(category).append(" ").append(elapsed).append("ms");
+		if (StringUtils.hasText(sql)) {
+			sb.append(highlight(format(sql)));
+		}
+		return sb.toString();
+	}
+
+	private String format(String sql) {
+		if (isDDL(sql)) {
+			return FormatStyle.DDL.getFormatter().format(sql);
+		} else if (isBasic(sql)) {
+			return FormatStyle.BASIC.getFormatter().format(sql);
+		}
+		return sql;
+	}
+
+	private String highlight(String sql) {
+		return FormatStyle.HIGHLIGHT.getFormatter().format(sql);
+	}
+
+	private boolean isDDL(String sql) {
+		return sql.startsWith("create") || sql.startsWith("alter") || sql.startsWith("comment");
+	}
+
+	private boolean isBasic(String sql) {
+		return sql.startsWith("select") || sql.startsWith("insert") || sql.startsWith("update") || sql.startsWith(
+			"delete");
+	}
+}

--- a/src/test/java/com/geonwoo/solokill/EnableQueryLog.java
+++ b/src/test/java/com/geonwoo/solokill/EnableQueryLog.java
@@ -1,0 +1,31 @@
+package com.geonwoo.solokill;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.properties.PropertyMapping;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+
+import com.geonwoo.solokill.global.config.P6SpyFormatter;
+import com.github.gavlyukovskiy.boot.jdbc.decorator.DataSourceDecoratorAutoConfiguration;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@ImportAutoConfiguration(DataSourceDecoratorAutoConfiguration.class)
+@Import(P6SpyFormatter.class)
+@TestPropertySource(properties = {
+	"logging.level.org.springframework.test.context=ERROR"
+})
+public @interface EnableQueryLog {
+
+	@PropertyMapping("spring.jpa.show-sql")
+	boolean showSql() default false;
+
+	@PropertyMapping("decorator.datasource.p6spy.enable-logging")
+	boolean enableLogging() default true;
+
+}

--- a/src/test/java/com/geonwoo/solokill/domain/matchrecord/controller/MatchRecordControllerTest.java
+++ b/src/test/java/com/geonwoo/solokill/domain/matchrecord/controller/MatchRecordControllerTest.java
@@ -1,0 +1,38 @@
+package com.geonwoo.solokill.domain.matchrecord.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class MatchRecordControllerTest {
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Test
+	@DisplayName("[성공] 사용자 이름으로 사용자가 최근 사용한 챔피언 이름을 반환한다.")
+	void getSummonerInfo() throws Exception {
+
+		String name = "리거누";
+
+		mockMvc.perform(MockMvcRequestBuilders.get("/matchRecord/{summonerName}", name)
+				.accept(MediaType.APPLICATION_JSON))
+			.andExpect(MockMvcResultMatchers.status().isOk())
+			.andDo(MockMvcResultHandlers.print());
+
+	}
+}

--- a/src/test/java/com/geonwoo/solokill/domain/matchrecord/repository/MatchRecordRepositoryTest.java
+++ b/src/test/java/com/geonwoo/solokill/domain/matchrecord/repository/MatchRecordRepositoryTest.java
@@ -1,8 +1,9 @@
 package com.geonwoo.solokill.domain.matchrecord.repository;
 
+import static org.assertj.core.api.Assertions.*;
+
 import java.util.Set;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,7 +17,7 @@ class MatchRecordRepositoryTest {
 	private MatchRecordRepository matchRecordRepository;
 
 	@Test
-	@Sql(scripts = {"/sql/Dummy.sql"})
+	@Sql(scripts = {"/sql/dummy.sql"})
 	@DisplayName("사용자의 puuid로 경기에서 사용한 챔피언의 이름을 조회한다.")
 	void findChampionNameByPuuid() {
 
@@ -27,6 +28,6 @@ class MatchRecordRepositoryTest {
 		Set<String> championNameByPuuid = matchRecordRepository.findChampionNameByPuuid(puuid);
 
 		//then
-		Assertions.assertThat(championNameByPuuid).contains("Jayce");
+		assertThat(championNameByPuuid).contains("Jayce");
 	}
 }

--- a/src/test/java/com/geonwoo/solokill/domain/matchrecord/service/MatchRecordServiceTest.java
+++ b/src/test/java/com/geonwoo/solokill/domain/matchrecord/service/MatchRecordServiceTest.java
@@ -1,0 +1,61 @@
+package com.geonwoo.solokill.domain.matchrecord.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.geonwoo.solokill.domain.matchrecord.repository.MatchRecordRepository;
+import com.geonwoo.solokill.domain.summoner.dto.SummonerInfoResponse;
+import com.geonwoo.solokill.domain.summoner.service.SummonerService;
+import com.geonwoo.solokill.global.client.service.ApiClientService;
+
+@ExtendWith(MockitoExtension.class)
+class MatchRecordServiceTest {
+
+	@Mock
+	private SummonerService summonerService;
+
+	@Mock
+	private ApiClientService apiClientService;
+
+	@Mock
+	private MatchRecordRepository matchRecordRepository;
+
+	@InjectMocks
+	private MatchRecordService matchRecordService;
+
+	@Test
+	void getPlayerChampionByName() {
+		String name = "리거누";
+		Set<String> championName = new HashSet<>();
+		championName.add("Jayce");
+		SummonerInfoResponse summonerInfoResponse = SummonerInfoResponse.builder()
+			.id("id")
+			.summonerLevel(234)
+			.name("리거누")
+			.puuid("puuid")
+			.profileIconId(123)
+			.build();
+
+		when(summonerService.getSummonerInfoByName(name)).thenReturn(summonerInfoResponse);
+		doNothing().when(apiClientService).getMatchInfoByPuuid(summonerInfoResponse.puuid());
+		when(matchRecordRepository.findChampionNameByPuuid(summonerInfoResponse.puuid())).thenReturn(championName);
+
+		List<String> responses = matchRecordService.getPlayerChampionByName(name);
+
+		assertTrue(responses.contains("Jayce"));
+
+		verify(summonerService).getSummonerInfoByName(name);
+		verify(apiClientService).getMatchInfoByPuuid("puuid");
+		verify(matchRecordRepository).findChampionNameByPuuid("puuid");
+	}
+}

--- a/src/test/java/com/geonwoo/solokill/domain/summoner/repository/SummonerRepositoryTest.java
+++ b/src/test/java/com/geonwoo/solokill/domain/summoner/repository/SummonerRepositoryTest.java
@@ -10,9 +10,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.jdbc.Sql;
 
+import com.geonwoo.solokill.EnableQueryLog;
 import com.geonwoo.solokill.domain.summoner.model.Summoner;
 
 @DataJpaTest
+@EnableQueryLog
 class SummonerRepositoryTest {
 
 	@Autowired

--- a/src/test/java/com/geonwoo/solokill/domain/summoner/repository/SummonerRepositoryTest.java
+++ b/src/test/java/com/geonwoo/solokill/domain/summoner/repository/SummonerRepositoryTest.java
@@ -22,7 +22,7 @@ class SummonerRepositoryTest {
 
 	@Test
 	@DisplayName("소환사 이름으로 소환사 정보를 조회한다.")
-	@Sql(scripts = {"/sql/Dummy.sql"})
+	@Sql(scripts = {"/sql/dummy.sql"})
 	void findByName() {
 
 		//given

--- a/src/test/java/com/geonwoo/solokill/domain/summoner/service/SummonerServiceTest.java
+++ b/src/test/java/com/geonwoo/solokill/domain/summoner/service/SummonerServiceTest.java
@@ -38,11 +38,9 @@ class SummonerServiceTest {
 		String name = "리거누";
 		Summoner summoner = Summoner.builder()
 			.id("id")
-			.accountId("accountId")
 			.puuid("puuid")
 			.name("리거누")
 			.profileIconId(123)
-			.revisionDate(1234L)
 			.summonerLevel(344)
 			.build();
 
@@ -56,10 +54,8 @@ class SummonerServiceTest {
 		assertNotNull(summonerInfoByName);
 		assertThat(summonerInfoByName)
 			.hasFieldOrPropertyWithValue("id", summoner.getId())
-			.hasFieldOrPropertyWithValue("accountId", summoner.getAccountId())
 			.hasFieldOrPropertyWithValue("puuid", summoner.getPuuid())
 			.hasFieldOrPropertyWithValue("profileIconId", summoner.getProfileIconId())
-			.hasFieldOrPropertyWithValue("revisionDate", summoner.getRevisionDate())
 			.hasFieldOrPropertyWithValue("summonerLevel", summoner.getSummonerLevel());
 
 		verify(summonerRepository).findByName(name);
@@ -73,11 +69,9 @@ class SummonerServiceTest {
 
 		SummonerInfoResponse summonerInfoResponse = SummonerInfoResponse.builder()
 			.id("id")
-			.accountId("accountId")
 			.puuid("puuid")
 			.name("리거누")
 			.profileIconId(123)
-			.revisionDate(1234L)
 			.summonerLevel(344)
 			.build();
 
@@ -90,10 +84,8 @@ class SummonerServiceTest {
 
 		assertThat(summonerInfoByName)
 			.hasFieldOrPropertyWithValue("id", summonerInfoByName.id())
-			.hasFieldOrPropertyWithValue("accountId", summonerInfoByName.accountId())
 			.hasFieldOrPropertyWithValue("puuid", summonerInfoByName.puuid())
 			.hasFieldOrPropertyWithValue("profileIconId", summonerInfoByName.profileIconId())
-			.hasFieldOrPropertyWithValue("revisionDate", summonerInfoByName.revisionDate())
 			.hasFieldOrPropertyWithValue("summonerLevel", summonerInfoByName.summonerLevel());
 
 		verify(summonerRepository).findByName(name);

--- a/src/test/java/com/geonwoo/solokill/global/client/feign/service/FeignApiClientServiceTest.java
+++ b/src/test/java/com/geonwoo/solokill/global/client/feign/service/FeignApiClientServiceTest.java
@@ -56,21 +56,17 @@ class FeignApiClientServiceTest {
 		String name = "리거누";
 		SummonerInfoResponse summonerInfoResponse = SummonerInfoResponse.builder()
 			.id("id")
-			.accountId("accountId")
 			.puuid("puuid")
 			.name("리거누")
 			.profileIconId(1234)
-			.revisionDate(1234L)
 			.summonerLevel(344)
 			.build();
 
 		Summoner summoner = Summoner.builder()
 			.id("id")
-			.accountId("accountId")
 			.puuid("puuid")
 			.name("리거누")
 			.profileIconId(1234)
-			.revisionDate(1234L)
 			.summonerLevel(344)
 			.build();
 
@@ -85,10 +81,8 @@ class FeignApiClientServiceTest {
 		//then
 		assertThat(summonerInfoByName)
 			.hasFieldOrPropertyWithValue("id", summonerInfoResponse.id())
-			.hasFieldOrPropertyWithValue("accountId", summonerInfoResponse.accountId())
 			.hasFieldOrPropertyWithValue("puuid", summonerInfoResponse.puuid())
 			.hasFieldOrPropertyWithValue("profileIconId", summonerInfoResponse.profileIconId())
-			.hasFieldOrPropertyWithValue("revisionDate", summonerInfoResponse.revisionDate())
 			.hasFieldOrPropertyWithValue("summonerLevel", summonerInfoResponse.summonerLevel());
 
 		verify(riotSummonerOpenFeign).getSummonerInfoByName(name);
@@ -123,11 +117,9 @@ class FeignApiClientServiceTest {
 
 		SummonerInfoResponse summonerInfoResponse = SummonerInfoResponse.builder()
 			.id("id")
-			.accountId("accountId")
 			.puuid("puuid")
 			.name("리거누")
 			.profileIconId(1234)
-			.revisionDate(1234L)
 			.summonerLevel(1234)
 			.build();
 

--- a/src/test/java/com/geonwoo/solokill/global/client/feign/service/FeignApiClientServiceTest.java
+++ b/src/test/java/com/geonwoo/solokill/global/client/feign/service/FeignApiClientServiceTest.java
@@ -18,7 +18,7 @@ import com.geonwoo.solokill.domain.matchrecord.dto.ChallengesResponse;
 import com.geonwoo.solokill.domain.matchrecord.dto.MatchInfo;
 import com.geonwoo.solokill.domain.matchrecord.dto.MatchResponse;
 import com.geonwoo.solokill.domain.matchrecord.dto.ParticipantResponse;
-import com.geonwoo.solokill.domain.matchrecord.repository.MatchInfoRepository;
+import com.geonwoo.solokill.domain.matchInfo.repository.MatchInfoRepository;
 import com.geonwoo.solokill.domain.matchrecord.repository.MatchRecordRepository;
 import com.geonwoo.solokill.domain.summoner.converter.SummonerConverter;
 import com.geonwoo.solokill.domain.summoner.dto.SummonerInfoResponse;
@@ -43,7 +43,7 @@ class FeignApiClientServiceTest {
 	private SummonerRepository summonerRepository;
 
 	@Mock
-	private MatchInfoRepository matchRepository;
+	private MatchInfoRepository matchInfoRepository;
 
 	@Mock
 	private MatchRecordRepository matchRecordRepository;
@@ -101,34 +101,27 @@ class FeignApiClientServiceTest {
 		String matchId = "matchId";
 		List<String> matchIds = new ArrayList<>();
 		matchIds.add(matchId);
-		when(riotMatchOpenFeign.getMatchId(puuid, gameType, gameCount)).thenReturn(matchIds);
 
 		ChallengesResponse challengesResponse = new ChallengesResponse(1);
-		ParticipantResponse participantResponse1 = new ParticipantResponse(puuid, 1, "TOP", "Jayce", challengesResponse,
-			1, 1, 1, 1, 1, 1, 1, 1, 1, true);
-		ParticipantResponse participantResponse2 = new ParticipantResponse(puuid1, 2, "TOP", "Gnar",
+		ParticipantResponse participantResponse1 = new ParticipantResponse(1, "TOP", "Jayce", challengesResponse,
+			1, 1, 1, 1, 1, 1, 1, 1, 1, true, "summoner1", puuid, "리거누", 1234, 324);
+		ParticipantResponse participantResponse2 = new ParticipantResponse(2, "TOP", "Gnar",
 			challengesResponse,
-			1, 1, 1, 1, 1, 1, 1, 1, 1, false);
+			1, 1, 1, 1, 1, 1, 1, 1, 1, false, "summoner2", puuid1, "Hide On Bush", 1234, 1234);
 		List<ParticipantResponse> participants = new ArrayList<>();
 		participants.add(participantResponse1);
 		participants.add(participantResponse2);
 		MatchInfo matchInfo = new MatchInfo(participants);
 		MatchResponse matchResponse = new MatchResponse(matchInfo);
 
-		SummonerInfoResponse summonerInfoResponse = SummonerInfoResponse.builder()
-			.id("id")
-			.puuid("puuid")
-			.name("리거누")
-			.profileIconId(1234)
-			.summonerLevel(1234)
-			.build();
-
+		when(riotMatchOpenFeign.getMatchId(puuid, gameType, gameCount)).thenReturn(matchIds);
 		when(riotMatchOpenFeign.getMatchByMatchId(matchId)).thenReturn(matchResponse);
-		when(riotSummonerOpenFeign.getSummonerInfoByPuuid(puuid)).thenReturn(summonerInfoResponse);
-		when(riotSummonerOpenFeign.getSummonerInfoByPuuid(puuid1)).thenReturn(summonerInfoResponse);
+		when(matchInfoRepository.existsById(matchId)).thenReturn(false);
+
 		feignApiClientService.getMatchInfoByPuuid(puuid);
 
 		verify(riotMatchOpenFeign).getMatchId(puuid, gameType, gameCount);
 		verify(riotMatchOpenFeign).getMatchByMatchId(matchId);
+		verify(matchInfoRepository).existsById(matchId);
 	}
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,5 +1,9 @@
 spring:
 
+  config:
+    import: optional:file:.env[.properties]
+
+
   datasource:
     url: jdbc:h2:mem:test;MODE=MySQL
     username: sa
@@ -18,6 +22,7 @@ spring:
         dialect: org.hibernate.dialect.H2Dialect
 
 riot-api:
+  key: ${API_KEY}
   url:
     kr: https://kr.api.riotgames.com
     asia: https://asia.api.riotgames.com

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -9,15 +9,20 @@ spring:
   jpa:
     open-in-view: false
     database: h2
-    show-sql: true
+    show-sql: false
     hibernate:
       ddl-auto: create
     properties:
       hibernate:
-        format_sql: true
+        format_sql: false
         dialect: org.hibernate.dialect.H2Dialect
 
 riot-api:
   url:
     kr: https://kr.api.riotgames.com
     asia: https://asia.api.riotgames.com
+
+decorator:
+  datasource:
+    p6spy:
+      enable-logging: true

--- a/src/test/resources/sql/Dummy.sql
+++ b/src/test/resources/sql/Dummy.sql
@@ -1,5 +1,5 @@
-insert into summoner (id, account_id, puuid, name, profile_icon_id, revision_date, summoner_level)
-values ('id', 'accountId', 'puuid', '리거누', 1234, 1234, 344);
+insert into summoner (id, puuid, name, profile_icon_id, summoner_level)
+values ('id', 'puuid', '리거누', 1234, 344);
 
 insert into match_info(id)
 values ('matchId');

--- a/src/test/resources/sql/dummy.sql
+++ b/src/test/resources/sql/dummy.sql
@@ -4,10 +4,10 @@ values ('id', 'puuid', '리거누', 1234, 344);
 insert into match_info(id)
 values ('matchId');
 
-insert into match_record (id, team_id, puuid, team_position, champion_id, champion_name, solo_kills,
+insert into match_record (team_id, summoner_id, team_position, champion_id, champion_name, solo_kills,
                           vision_score, vision_wards_bought_in_game, total_minions_killed,
                           total_damage_dealt_to_champions,
                           gold_earned, kills, deaths, assists, win, match_info_id)
-values (1, 1, 'puuid', 'TOP', 1, 'Jayce', 1, 1, 1, 1, 1, 1, 1, 1, 1, true, 'matchId');
+values (1, 'summoner_id', 'TOP', 1, 'Jayce', 1, 1, 1, 1, 1, 1, 1, 1, 1, true, 'matchId');
 
 

--- a/src/test/resources/sql/dummy.sql
+++ b/src/test/resources/sql/dummy.sql
@@ -1,5 +1,5 @@
 insert into summoner (id, puuid, name, profile_icon_id, summoner_level)
-values ('id', 'puuid', '리거누', 1234, 344);
+values ('summoner_id', 'puuid', '리거누', 1234, 344);
 
 insert into match_info(id)
 values ('matchId');


### PR DESCRIPTION
## ✅ 작업 사항

### 🧙 Summoner 리펙토링
- summoner insert시 select쿼리가 나가지 않도록 수정
- 소환사의 최근 사용 챔피언 조회 로직 수정
   - Riot Api 호출 횟수 감소
   - MatchRecord 복합키 사용

### 💡 관련 이슈
- resolves #27 