### PR TITLE
[#29] 최근 사용 챔피언 조회 쿼리 수정

### DIFF
--- a/src/main/java/com/geonwoo/solokill/domain/matchrecord/converter/MatchRecordConverter.java
+++ b/src/main/java/com/geonwoo/solokill/domain/matchrecord/converter/MatchRecordConverter.java
@@ -29,16 +29,6 @@ public class MatchRecordConverter {
 			.win(participantResponse.win())
 			.build();
 
-		Summoner summoner = Summoner.builder()
-			.id(participantResponse.summonerId())
-			.name(participantResponse.summonerName())
-			.puuid(participantResponse.puuid())
-			.profileIconId(participantResponse.profileIcon())
-			.summonerLevel(participantResponse.summonerLevel())
-			.build();
-
-		matchRecord.addSummoner(summoner);
-
 		return matchRecord;
 	}
 }

--- a/src/main/java/com/geonwoo/solokill/domain/matchrecord/repository/MatchRecordRepository.java
+++ b/src/main/java/com/geonwoo/solokill/domain/matchrecord/repository/MatchRecordRepository.java
@@ -16,9 +16,9 @@ public interface MatchRecordRepository
 	@Query("""
 		SELECT m.championName
 		FROM MatchRecord m
-		WHERE m.summoner.puuid = :puuid
+		WHERE m.matchRecordPk.summonerId = :id
 		""")
-	Set<String> findChampionNameByPuuid(@Param("puuid") String puuid);
+	Set<String> findChampionNameBySummonerId(@Param("id") String id);
 
 	@Query("""
 		SELECT m

--- a/src/main/java/com/geonwoo/solokill/domain/matchrecord/service/MatchRecordService.java
+++ b/src/main/java/com/geonwoo/solokill/domain/matchrecord/service/MatchRecordService.java
@@ -31,7 +31,7 @@ public class MatchRecordService {
 	public List<String> getPlayerChampionByName(String name) {
 		SummonerInfoResponse summonerInfoByName = summonerService.getSummonerInfoByName(name);
 		apiClientService.getMatchInfoByPuuid(summonerInfoByName.puuid());
-		Set<String> championNameByPuuid = matchRecordRepository.findChampionNameByPuuid(summonerInfoByName.puuid());
+		Set<String> championNameByPuuid = matchRecordRepository.findChampionNameBySummonerId(summonerInfoByName.id());
 		return championNameByPuuid.stream().toList();
 	}
 

--- a/src/main/java/com/geonwoo/solokill/global/client/feign/service/FeignApiClientService.java
+++ b/src/main/java/com/geonwoo/solokill/global/client/feign/service/FeignApiClientService.java
@@ -56,9 +56,17 @@ public class FeignApiClientService implements ApiClientService {
 
 				matchResponse.info().participants().forEach(participantResponse ->
 					{
-						if (!summonerRepository.existsById(participantResponse.summonerId()) &&
-							!matchRecordRepository.existsById(new MatchRecordPk(participantResponse.summonerId(), matchId))) {
+						if (!matchRecordRepository.existsById(new MatchRecordPk(participantResponse.summonerId(), matchId))) {
 							MatchRecord matchRecord = MatchRecordConverter.toMatchRecord(participantResponse, matchId);
+							Summoner summoner = summonerRepository.findById(participantResponse.summonerId()).orElseGet(()->
+								SummonerConverter.toSummoner(new SummonerInfoResponse(
+									participantResponse.summonerId(),
+									participantResponse.puuid(),
+									participantResponse.summonerName(),
+									participantResponse.profileIcon(),
+									participantResponse.summonerLevel()))
+							);
+							matchRecord.addSummoner(summoner);
 							matchRecord.addMatch(matchInfo);
 							matchRecordRepository.save(matchRecord);
 						}

--- a/src/test/java/com/geonwoo/solokill/domain/matchrecord/repository/MatchRecordRepositoryTest.java
+++ b/src/test/java/com/geonwoo/solokill/domain/matchrecord/repository/MatchRecordRepositoryTest.java
@@ -25,7 +25,7 @@ class MatchRecordRepositoryTest {
 		String puuid = "puuid";
 
 		//when
-		Set<String> championNameByPuuid = matchRecordRepository.findChampionNameByPuuid(puuid);
+		Set<String> championNameByPuuid = matchRecordRepository.findChampionNameBySummonerId(puuid);
 
 		//then
 		assertThat(championNameByPuuid).contains("Jayce");

--- a/src/test/java/com/geonwoo/solokill/domain/matchrecord/repository/MatchRecordRepositoryTest.java
+++ b/src/test/java/com/geonwoo/solokill/domain/matchrecord/repository/MatchRecordRepositoryTest.java
@@ -18,16 +18,16 @@ class MatchRecordRepositoryTest {
 
 	@Test
 	@Sql(scripts = {"/sql/dummy.sql"})
-	@DisplayName("사용자의 puuid로 경기에서 사용한 챔피언의 이름을 조회한다.")
+	@DisplayName("사용자의 d로 경기에서 사용한 챔피언의 이름을 조회한다.")
 	void findChampionNameByPuuid() {
 
 		//given
-		String puuid = "puuid";
+		String id = "summoner_id";
 
 		//when
-		Set<String> championNameByPuuid = matchRecordRepository.findChampionNameBySummonerId(puuid);
+		Set<String> championNameById = matchRecordRepository.findChampionNameBySummonerId(id);
 
 		//then
-		assertThat(championNameByPuuid).contains("Jayce");
+		assertThat(championNameById).contains("Jayce");
 	}
 }

--- a/src/test/java/com/geonwoo/solokill/domain/matchrecord/service/MatchRecordServiceTest.java
+++ b/src/test/java/com/geonwoo/solokill/domain/matchrecord/service/MatchRecordServiceTest.java
@@ -48,7 +48,7 @@ class MatchRecordServiceTest {
 
 		when(summonerService.getSummonerInfoByName(name)).thenReturn(summonerInfoResponse);
 		doNothing().when(apiClientService).getMatchInfoByPuuid(summonerInfoResponse.puuid());
-		when(matchRecordRepository.findChampionNameByPuuid(summonerInfoResponse.puuid())).thenReturn(championName);
+		when(matchRecordRepository.findChampionNameBySummonerId(summonerInfoResponse.puuid())).thenReturn(championName);
 
 		List<String> responses = matchRecordService.getPlayerChampionByName(name);
 
@@ -56,6 +56,6 @@ class MatchRecordServiceTest {
 
 		verify(summonerService).getSummonerInfoByName(name);
 		verify(apiClientService).getMatchInfoByPuuid("puuid");
-		verify(matchRecordRepository).findChampionNameByPuuid("puuid");
+		verify(matchRecordRepository).findChampionNameBySummonerId("puuid");
 	}
 }

--- a/src/test/java/com/geonwoo/solokill/domain/matchrecord/service/MatchRecordServiceTest.java
+++ b/src/test/java/com/geonwoo/solokill/domain/matchrecord/service/MatchRecordServiceTest.java
@@ -48,7 +48,7 @@ class MatchRecordServiceTest {
 
 		when(summonerService.getSummonerInfoByName(name)).thenReturn(summonerInfoResponse);
 		doNothing().when(apiClientService).getMatchInfoByPuuid(summonerInfoResponse.puuid());
-		when(matchRecordRepository.findChampionNameBySummonerId(summonerInfoResponse.puuid())).thenReturn(championName);
+		when(matchRecordRepository.findChampionNameBySummonerId(summonerInfoResponse.id())).thenReturn(championName);
 
 		List<String> responses = matchRecordService.getPlayerChampionByName(name);
 
@@ -56,6 +56,6 @@ class MatchRecordServiceTest {
 
 		verify(summonerService).getSummonerInfoByName(name);
 		verify(apiClientService).getMatchInfoByPuuid("puuid");
-		verify(matchRecordRepository).findChampionNameBySummonerId("puuid");
+		verify(matchRecordRepository).findChampionNameBySummonerId("id");
 	}
 }


### PR DESCRIPTION
## ✅ 작업 사항

### 🥊 최근 사용 챔피언 조회 쿼리 수정
- where 조건절에서 puuid에서 id를 사용하도록 수정
- Summoner가 Session에 있으면 사용하고 없으면 Summoner 객체를 만들어서 사용하도록 수정

### 💡 관련 이슈
- resolves #29 